### PR TITLE
Fund a large amount of accounts

### DIFF
--- a/hardhat.config.local.js
+++ b/hardhat.config.local.js
@@ -29,6 +29,8 @@ module.exports = {
   solidity: "0.7.6",
   networks: {
     hardhat: {
+      // Provide a large amount of funded accounts for large scale tests
+      accounts: {count:1000},
       chainId: 1337,
     },
   },


### PR DESCRIPTION
Fixes #8 

This modifies the `hardhat` config to fund `1000` accounts instead of the default of `20`. 

On my local machine this did mean starting the container can take a few seconds. However since it tends to be a long running process I don't think that's too big a deal.